### PR TITLE
Add build support for python 3.10

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
-        pyver: [3.6, 3.7, 3.8, 3.9, 3.10]
+        pyver: ['3.6', '3.7', '3.8', '3.9', '3.10']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pyver: [3.6, 3.7, 3.8, 3.9, 3.10]
+        pyver: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
-        pyver: [3.6, 3.7, 3.8, 3.9]
+        pyver: [3.6, 3.7, 3.8, 3.9, 3.10]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pyver: [3.6, 3.7, 3.8, 3.9]
+        pyver: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,11 @@ install_requires =
     pyxdg==0.27
     coqpit==0.0.9
     Flask-SocketIO==4.3.2
+    Werkzeug<2.1  # 2.1 drops py3.6 . Dependency of our (out of date) SocketIO
     webrtcvad==2.0.10
     stt==1.3.0
     requests==2.25.1
-python_requires = >=3.6,<3.10
+python_requires = >=3.6,<3.11
 
 [options.package_data]
 coqui_stt_model_manager = templates/*, static/build/*, static/build/static/js/*, static/build/static/css/*


### PR DESCRIPTION
Readd build support for python 3.10 by pinning Werkzeug<2.10. Werkzeug comes from our use of Flask-SocketIO. Note that Werkzeug 2.10 also drops python 3.6 support.

Closes issues #34 and #35.