### PR TITLE
Change stt version to >=1.3, <2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     coqpit==0.0.9
     Flask-SocketIO==4.3.2
     webrtcvad==2.0.10
-    stt==1.3.0
+    stt >=1.3, <2
     requests==2.25.1
 python_requires = >=3.6,<3.10
 


### PR DESCRIPTION
Relates to issue #33.

Since STT will be following semantic versioning, I think it makes sense to specify a range for the stt dependency. This will also allow the stt dependency to be updated without changes to this repo.