### PR TITLE
Loosen pip requirements for stt<2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,9 @@ install_requires =
     Flask-SocketIO==4.3.2
     Werkzeug<2.1  # 2.1 drops py3.6 . Dependency of our (out of date) SocketIO
     webrtcvad==2.0.10
-    stt==1.3.0
+    stt<2.0.0
     requests==2.25.1
-python_requires = >=3.6,<3.11
+python_requires = >=3.7,<3.11
 
 [options.package_data]
 coqui_stt_model_manager = templates/*, static/build/*, static/build/static/js/*, static/build/static/css/*


### PR DESCRIPTION
Should comply with #38  and allow anyone to use the version of STT of their choice.

Provided we update the pip repo with version 0.0.20 of `coqui_stt_model_manager`.